### PR TITLE
Add check to render inline when view permission present

### DIFF
--- a/fieldsets_with_inlines/mixins.py
+++ b/fieldsets_with_inlines/mixins.py
@@ -36,6 +36,7 @@ class FieldsetsInlineMixin(object):
                 if request:
                     if not (inline.has_add_permission(request, obj) or
                             inline.has_change_permission(request, obj) or
+                            inline.has_view_permission(request, obj) or
                             inline.has_delete_permission(request, obj)):
                         continue
                     if not inline.has_add_permission(request, obj):


### PR DESCRIPTION
[Django release 2.1](https://docs.djangoproject.com/en/2.1/releases/2.1/#model-view-permission) added the view permission. Since the code doesn't check for this permission it won't render inlines as view only when it should.