### PR TITLE
Add support to add view and extend parent class template

### DIFF
--- a/fieldsets_with_inlines/mixins.py
+++ b/fieldsets_with_inlines/mixins.py
@@ -3,6 +3,27 @@ from django import forms
 
 class FieldsetsInlineMixin(object):
     change_form_template = 'fieldsets_with_inlines/change_form.html'
+    add_form_template = 'fieldsets_with_inlines/change_form.html'
+
+    def add_view(self, *args, extra_context=None, **kwargs):
+        extra_context = extra_context or {}
+        extra_context["original_template"] = (
+            super().add_form_template or "admin/change_form.html"
+        )
+
+        return super().add_view(
+            *args, extra_context=extra_context, **kwargs
+        )
+
+    def change_view(self, *args, extra_context=None, **kwargs):
+        extra_context = extra_context or {}
+        extra_context["original_template"] = (
+            super().change_form_template or "admin/change_form.html"
+        )
+
+        return super().change_view(
+            *args, extra_context=extra_context, **kwargs
+        )
 
     def make_placeholder(self, index, fieldset):
         if isinstance(fieldset, forms.MediaDefiningClass):

--- a/fieldsets_with_inlines/templates/fieldsets_with_inlines/change_form.html
+++ b/fieldsets_with_inlines/templates/fieldsets_with_inlines/change_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_form.html" %}
+{% extends original_template %}
 {% load i18n admin_urls static admin_modify %}
 
 


### PR DESCRIPTION
This PR introduces two related changes:

1. Add support to add views. Previously only change views were supported.

2. Instead of hardcoding the template which this app's template extends, use the parent's template choice to extend. Achieve this by overriding the `add_view` and `change_view` methods to include an extra context variable holding the parent's chosen template.

   For example, the UserAdmin (the default user's `AdminModel` class) uses a different `add_form_template` from the regular `AdminModel` (it uses `admin/auth/user/add_form.html`, while the regular AdminModel uses `admin/change_form.html`). This commit will make the `FieldsetsInlineMixin` function properly when subclassed with `UserAdmin`